### PR TITLE
Revert "Merge pull request #17 from ipear3/0.0.10"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,8 @@ jobs:
     name: release
     runs-on: ubuntu-latest
     environment: release
-    permissions: write-all
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
This reverts commit 5b7982b9c6190523fb1cdcc5a996e7084742a5a9, reversing changes made to 78a60b11a87a8fe2e5dfaf690b61714d2b975f09.

I was wrong about the permissions being incorrect. It was a protected tag that was preventing github acitons from creating the release.